### PR TITLE
use single-block-messages in request and response

### DIFF
--- a/include/libKitsunemimiProjectNetwork/session.h
+++ b/include/libKitsunemimiProjectNetwork/session.h
@@ -96,14 +96,12 @@ public:
     uint64_t m_sessionIdentifier = 0;
 
     // init session
-    bool connectiSession(const uint32_t sessionId,
-                         const uint64_t sessionIdentifier,
-                         const bool init = false);
+    bool connectiSession(const uint32_t sessionId);
     bool makeSessionReady(const uint32_t sessionId,
                           const uint64_t sessionIdentifier);
 
     // end session
-    bool endSession(const bool init = false);
+    bool endSession();
     bool disconnectSession();
 
     bool sendHeartbeat();

--- a/src/message_definitions.h
+++ b/src/message_definitions.h
@@ -451,6 +451,7 @@ struct Data_SingleBlock_Message
     CommonMessageHeader commonHeader;
     uint64_t multiblockId = 0;
     uint64_t payloadSize = 0;
+    uint64_t blockerId = 0;
     uint8_t payload[1000];
     uint8_t padding[4];
     CommonMessageEnd commonEnd;
@@ -460,7 +461,8 @@ inline void
 create_Data_SingleBlock_Message(Data_SingleBlock_Message &target,
                                 const uint32_t sessionId,
                                 const uint32_t messageId,
-                                const uint64_t multiblockId)
+                                const uint64_t multiblockId,
+                                const uint64_t blockerId)
 {
     target.commonHeader.type = SINGLEBLOCK_DATA_TYPE;
     target.commonHeader.subType = DATA_SINGLE_DATA_SUBTYPE;
@@ -468,6 +470,7 @@ create_Data_SingleBlock_Message(Data_SingleBlock_Message &target,
     target.commonHeader.messageId = messageId;
     target.commonHeader.size = sizeof(target);
     target.commonHeader.flags = 0x1;
+    target.blockerId = blockerId;
     target.multiblockId = multiblockId;
 }
 

--- a/src/messages_processing/session_processing.h
+++ b/src/messages_processing/session_processing.h
@@ -161,7 +161,7 @@ process_Session_Init_Start(Session* session,
 
     // create new session and make it ready
     SessionHandler::m_sessionHandler->addSession(sessionId, session);
-    session->connectiSession(sessionId, false);
+    session->connectiSession(sessionId);
     session->makeSessionReady(sessionId, sessionIdentifier);
 
     // confirm id

--- a/src/messages_processing/singleblock_data_processing.h
+++ b/src/messages_processing/singleblock_data_processing.h
@@ -52,13 +52,15 @@ inline void
 send_Data_SingleBlock(Session* session,
                       const uint64_t multiblockId,
                       const void* data,
-                      uint64_t size)
+                      uint64_t size,
+                      const uint64_t blockerId=0)
 {
     Data_SingleBlock_Message message;
     create_Data_SingleBlock_Message(message,
                                     session->sessionId(),
                                     session->increaseMessageIdCounter(),
-                                    multiblockId);
+                                    multiblockId,
+                                    blockerId);
 
     memcpy(message.payload, data, size);
     message.payloadSize = size;

--- a/src/multiblock_io.cpp
+++ b/src/multiblock_io.cpp
@@ -49,7 +49,6 @@ std::pair<DataBuffer*, uint64_t>
 MultiblockIO::createOutgoingBuffer(const void* data,
                                    const uint64_t size,
                                    const bool answerExpected,
-                                   const uint64_t blockerTimeout,
                                    const uint64_t blockerId)
 {
     std::pair<DataBuffer*, uint64_t> result;
@@ -64,7 +63,6 @@ MultiblockIO::createOutgoingBuffer(const void* data,
     newMultiblockMessage.multiBlockBuffer = new Kitsunemimi::DataBuffer(numberOfBlocks);
     newMultiblockMessage.messageSize = size;
     newMultiblockMessage.multiblockId = newMultiblockId;
-    newMultiblockMessage.answerExpected = answerExpected;
     newMultiblockMessage.blockerId = blockerId;
 
     Kitsunemimi::addDataToBuffer(newMultiblockMessage.multiBlockBuffer, data, size);
@@ -79,13 +77,6 @@ MultiblockIO::createOutgoingBuffer(const void* data,
     m_outgoing_lock.clear(std::memory_order_release);
 
     send_Data_Multi_Init(m_session, newMultiblockId, size, answerExpected);
-
-    if(answerExpected)
-    {
-        result.first = SessionHandler::m_blockerHandler->blockMessage(newMultiblockId,
-                                                                      blockerTimeout,
-                                                                      m_session);
-    }
 
     result.second = newMultiblockId;
 

--- a/src/multiblock_io.h
+++ b/src/multiblock_io.h
@@ -50,7 +50,6 @@ public:
         bool isReady = false;
         bool currentSend = false;
         uint64_t blockerId = 0;
-        bool answerExpected = false;
         uint64_t multiblockId = 0;
         uint64_t messageSize = 0;
         uint32_t numberOfPackages = 0;
@@ -66,7 +65,6 @@ public:
     std::pair<DataBuffer*, uint64_t> createOutgoingBuffer(const void* data,
                                                           const uint64_t size,
                                                           const bool answerExpected=false,
-                                                          const uint64_t blockerTimeout=0,
                                                           const uint64_t blockerId=0);
     bool createIncomingBuffer(const uint64_t multiblockId,
                               const uint64_t size);

--- a/src/session_constroller.cpp
+++ b/src/session_constroller.cpp
@@ -26,6 +26,7 @@
 #include <handler/message_blocker_handler.h>
 #include <handler/session_handler.h>
 #include <callbacks.h>
+#include <messages_processing/session_processing.h>
 
 #include <libKitsunemimiNetwork/tcp/tcp_server.h>
 #include <libKitsunemimiNetwork/tcp/tcp_socket.h>
@@ -389,7 +390,13 @@ SessionController::startSession(Network::AbstractSocket *socket,
     const uint32_t newId = SessionHandler::m_sessionHandler->increaseSessionIdCounter();
     SessionHandler::m_sessionHandler->addSession(newId, newSession);
 
-    return newSession->connectiSession(newId, sessionIdentifier, true);
+    if(newSession->connectiSession(newId))
+    {
+        send_Session_Init_Start(newSession, sessionIdentifier);
+        return true;
+    }
+
+    return false;
 }
 
 //==================================================================================================


### PR DESCRIPTION
## Description

- use single-block-messages for small request- and response-messages
- cleanup methods for session init and end

## Related Issues

- close #83 

## How it was tested?

- functional tests
