### PR TITLE
fix crash on systems with only one cpu-thread

### DIFF
--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -93,11 +93,8 @@ processMessage(void* target,
     }
 
     // remove from reply-handler if message is reply
-    if(header->flags & 0x2)
-    {
-        bool found = SessionHandler::m_replyHandler->removeMessage(header->sessionId,
-                                                                   header->messageId);
-        assert(found);
+    if(header->flags & 0x2) {
+        SessionHandler::m_replyHandler->removeMessage(header->sessionId, header->messageId);
     }
 
     // process message by type


### PR DESCRIPTION
double-removing of messages from the reply-handler doesn't result in a crash anymore

## Description

## Related Issues

- close #90 

## How it was tested?

- functional-test
- benchmark-test
